### PR TITLE
Fixed yylloc in scanner

### DIFF
--- a/include/ast.h
+++ b/include/ast.h
@@ -6,43 +6,116 @@
 
 #define JSON_TAB_WIDTH 4
 
+/* AST Node */
 typedef struct ast_node        ASTNode;
 typedef struct ast_node_data   ASTNodeData;
 typedef struct ast_node_vtable ASTNodeVTable;
-
 struct ast_node {
     void *data;
     void *vtable;
 };
-
 struct ast_node_data {
     struct YYLTYPE *loc;
 };
-
 struct ast_node_vtable {
     void   (*free)(const void*);
     void   (*json)(const void*, int, FILE*);
 };
-
 void free_ASTNode(const void*);
 
+
+/* Leaf Node */
 const ASTNode *new_LeafNode(struct YYLTYPE *loc);
 
+
+/* Program Node < AST Node */
 typedef struct ast_program_data   ASTProgramData;
 typedef struct ast_program_vtable ASTProgramVTable;
-
-
 struct ast_program_data {
     struct YYLTYPE *loc;
     const Vector *statements;
 };
-
 struct ast_program_vtable {
     void   (*free)(const void*);
     void   (*json)(const void*, int, FILE*);
 };
-
 const ASTNode *new_ProgramNode(struct YYLTYPE *loc, const Vector *statements);
 
+
+/* Statement Node < AST Node */
+typedef struct ast_statement_data   ASTStatementData;
+typedef struct ast_statement_vtable ASTStatementVTable;
+struct ast_statement_data {
+    struct YYLTYPE *loc;
+};
+struct ast_statement_vtable {
+    void   (*free)(const void*);
+    void   (*json)(const void*, int, FILE*);
+};
+
+
+/* Assignment Node < Statement Node */
+typedef struct ast_assignment_data   ASTAssignmentData;
+typedef struct ast_assignment_vtable ASTAssignmentVTable;
+struct ast_assignment_data {
+    struct YYLTYPE *loc;
+    const void *lhs;
+    const void *rhs;
+};
+struct ast_assignment_vtable {
+    void   (*free)(const void*);
+    void   (*json)(const void*, int, FILE*);
+};
+const ASTNode *new_AssignmentNode(struct YYLTYPE *loc,
+                                  const void *lhs,
+                                  const void *rhs);
+
+/* RExpr Node < Statement Node */
+typedef struct ast_r_expr_data   ASTRExprData;
+typedef struct ast_r_expr_vtable ASTRExprVTable;
+struct ast_r_expr_data {
+    struct YYLTYPE *loc;
+};
+struct ast_r_expr_vtable {
+    void   (*free)(const void*);
+    void   (*json)(const void*, int, FILE*);
+};
+
+/* LExpr Node < RExpr Node */
+typedef struct ast_l_expr_data   ASTLExprData;
+typedef struct ast_l_expr_vtable ASTLExprVTable;
+struct ast_l_expr_data {
+    struct YYLTYPE *loc;
+};
+struct ast_l_expr_vtable {
+    void   (*free)(const void*);
+    void   (*json)(const void*, int, FILE*);
+};
+
+/* Variable Node < LExpr Node */
+typedef struct ast_variable_data   ASTVariableData;
+typedef struct ast_variable_vtable ASTVariableVTable;
+struct ast_variable_data {
+    struct YYLTYPE *loc;
+    char *name;
+};
+struct ast_variable_vtable {
+    void   (*free)(const void*);
+    void   (*json)(const void*, int, FILE*);
+};
+const ASTNode *new_VariableNode(struct YYLTYPE *loc, char *name);
+
+/* Int Node < LExpr Node */
+typedef struct ast_int_data   ASTIntData;
+typedef struct ast_int_vtable ASTIntVTable;
+struct ast_int_data {
+    struct YYLTYPE *loc;
+    int val;
+};
+struct ast_int_vtable {
+    void   (*free)(const void*);
+    void   (*json)(const void*, int, FILE*);
+};
+const ASTNode *new_IntNode(struct YYLTYPE *loc, int val);
 
 #endif//AST_H

--- a/src/parser.y
+++ b/src/parser.y
@@ -53,7 +53,7 @@
 %token<double_val> DOUBLE_LIT
 %token<str_val>    IDENT
 
-%type<ast> file statement
+%type<ast> file statement assignment lvalue expr
 %type<vec> stmts
 
 %start file
@@ -83,19 +83,40 @@ stmts:
         }
 
 statement:
-    IDENT '=' expr NEWLINE
+    assignment NEWLINE
         {
-            $$ = new_LeafNode(&@$);
-            free($1);
+            $$ = $1;
+        }
+
+assignment:
+    expr
+        {
+            $$ = $1;
+        }
+  | lvalue '=' assignment
+        {
+            $$ = new_AssignmentNode(&@$, $1, $3);
+        }
+
+lvalue:
+    IDENT
+        {
+            $$ = new_VariableNode(&@$, $1);
         }
 
 expr:
-    IDENT
+    lvalue
         {
-            free($1);
+            $$ = $1;
         }
   | INT_LIT
+        {
+            $$ = new_IntNode(&@$, $1);
+        };
   | DOUBLE_LIT
+        {
+            $$ = new_LeafNode(&@$);
+        };
 
 %%
 

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -7,15 +7,18 @@
 
 const Stack *indent_stack;
 const Queue *tok_queue;
+YYLTYPE save_loc = { 1, 1, 1, 1 };
 int indent = 0;
 enum { NOT_SET, SPACES, TABS } indent_type = NOT_SET;
 
 typedef struct token {
     enum yytokentype type;
     union YYSTYPE value;
+    YYLTYPE loc;
 } Token;
 
 #define YY_USER_ACTION \
+    *yylloc = save_loc; \
     yylloc->first_line = yylloc->last_line; \
     yylloc->first_column = yylloc->last_column; \
     for (int i = 0; yytext[i] != '\0'; i++) { \
@@ -25,7 +28,8 @@ typedef struct token {
         } else { \
             yylloc->last_column++; \
         } \
-    }
+    } \
+    save_loc = *yylloc;
 #define YY_USER_INIT { \
     tok_queue    = new_Queue(0); \
     indent_stack = new_Stack(0); \
@@ -60,6 +64,7 @@ void yyerror(YYLTYPE *locp,
 void push_token(Token t) {
     Token *new_t = malloc(sizeof(*new_t));
     memcpy(new_t, &t, sizeof(*new_t));
+    new_t->loc = save_loc;
     safe_call(tok_queue, push, new_t);
 }
 
@@ -79,7 +84,7 @@ int handle_indentation(int indent_len) {
         while (indent_stack->size(indent_stack) && *top_indent > indent_len) {
             safe_call(indent_stack, pop, &top_indent);
             free(top_indent);
-            push_token((Token){.type=OUTDENT});
+            push_token((Token){ .type=OUTDENT });
             safe_call(indent_stack, top, &top_indent);
         }
         if (*top_indent < indent_len) {
@@ -89,12 +94,13 @@ int handle_indentation(int indent_len) {
     return 0;
 }
 
-int pop_token_queue(YYSTYPE *lval, enum yytokentype *type) {
+int pop_token_queue(YYSTYPE *lval, enum yytokentype *type, YYLTYPE *loc) {
     if (tok_queue->size(tok_queue) != 0) {
         Token *t;
         safe_call(tok_queue, pop, &t);
         *type = t->type;
         *lval = t->value;
+        *loc  = t->loc;
         free(t);
         switch(*type) {
             case NEWLINE:
@@ -116,7 +122,7 @@ int pop_token_queue(YYSTYPE *lval, enum yytokentype *type) {
                 printf("DOUBLE_LIT (%f)\n", lval->double_val);
                 break;
             case IDENT:
-                printf("IDENT     (%s)\n", lval->str_val);
+                printf("IDENT      (%s)\n", lval->str_val);
                 break;
             default:
                 printf("LITERAL    (%c)\n", *type);
@@ -139,7 +145,7 @@ int pop_token_queue(YYSTYPE *lval, enum yytokentype *type) {
 
 %{
     enum yytokentype type;
-    if (pop_token_queue(yylval, &type)) {
+    if (pop_token_queue(yylval, &type, yylloc)) {
         return type;
     }
 %}
@@ -159,13 +165,11 @@ int pop_token_queue(YYSTYPE *lval, enum yytokentype *type) {
     push_token((Token){.type=IDENT,      .value.str_val=strdup(yytext)});
 }
 
-
-
 "\n" {
     push_token((Token){.type=NEWLINE});
     indent = 0;
     enum yytokentype type;
-    if (pop_token_queue(yylval, &type)) {
+    if (pop_token_queue(yylval, &type, yylloc)) {
         return type;
     }
 }
@@ -213,7 +217,7 @@ int pop_token_queue(YYSTYPE *lval, enum yytokentype *type) {
         push_token((Token){.type=OUTDENT});
     }
     enum yytokentype type;
-    if (pop_token_queue(yylval, &type)) {
+    if (pop_token_queue(yylval, &type, yylloc)) {
         return type;
     }
     if (tok_queue->size(tok_queue)) {


### PR DESCRIPTION
When tokens were queued, their location values were lost. Now, a copy of
yylloc is stored alongside each token in the queue.